### PR TITLE
Add shift request creation endpoint and integrate

### DIFF
--- a/src/app/search-shifts/page.tsx
+++ b/src/app/search-shifts/page.tsx
@@ -5,6 +5,7 @@ import { useAuth } from "../../hooks/useAuth";
 import {
   useAvailableShifts,
   useRequestShift,
+  useCreateShiftRequest,
 } from "../../hooks/usePromoterData";
 import AppLayout from "../../components/Layout/AppLayout";
 import ProtectedRoute from "../../components/ProtectedRoute";
@@ -40,7 +41,7 @@ export default function SearchShiftsPage() {
     refetch,
   } = useAvailableShifts(currentPage, 10);
 
-  const requestShiftMutation = useRequestShift();
+  const requestShiftMutation = useCreateShiftRequest();
 
   const handlePageChange = (_: React.ChangeEvent<unknown>, value: number) => {
     setCurrentPage(value);

--- a/src/hooks/usePromoterData.ts
+++ b/src/hooks/usePromoterData.ts
@@ -117,6 +117,27 @@ export const useRequestShift = () => {
   });
 };
 
+export const useCreateShiftRequest = () => {
+  const queryClient = useQueryClient();
+  
+  return useMutation({
+    mutationFn: ({ shiftId, promoterId }: { shiftId: string; promoterId: string }) =>
+      shiftService.createShiftRequest(shiftId, promoterId),
+    onSuccess: (data, variables) => {
+      // Invalidar queries relacionadas
+      queryClient.invalidateQueries({ 
+        queryKey: QUERY_KEYS.PROMOTER_SHIFTS(variables.promoterId) 
+      });
+      queryClient.invalidateQueries({ 
+        queryKey: QUERY_KEYS.AVAILABLE_SHIFTS() 
+      });
+      queryClient.invalidateQueries({ 
+        queryKey: QUERY_KEYS.DASHBOARD_DATA(variables.promoterId) 
+      });
+    },
+  });
+};
+
 export const useStartShift = () => {
   const queryClient = useQueryClient();
   

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -180,6 +180,17 @@ export class ShiftService extends BaseApiService {
     return response.data;
   }
 
+  async createShiftRequest(shiftId: string, promoterId: string): Promise<Shift> {
+    const response: any = await this.api.post<ApiResponse<Shift>>(
+      `/shifts/requests`,
+      {
+        shiftId,
+        promoterId,
+      }
+    );
+    return response.data;
+  }
+
   async startShift(shiftId: string, promoterId: string): Promise<ActiveShift> {
     const response: any = await this.api.post<ApiResponse<ActiveShift>>(
       `/promoter/shifts/${shiftId}/start`,
@@ -296,6 +307,8 @@ export const shiftAPI = {
   getAvailableShifts: () => shiftService.getAvailableShifts(),
   requestShift: (userId: string, shiftId: string) =>
     shiftService.requestShift(shiftId, userId),
+  createShiftRequest: (userId: string, shiftId: string) =>
+    shiftService.createShiftRequest(shiftId, userId),
 };
 
 export const performanceAPI = {


### PR DESCRIPTION
Integrate new `/shifts/requests` endpoint for creating shift requests to align with updated API structure.

---
<a href="https://cursor.com/background-agent?bcId=bc-b705f61a-acb7-41ee-a418-a5731c03cb93">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b705f61a-acb7-41ee-a418-a5731c03cb93">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>